### PR TITLE
Add block storage for MLFlow, Grafana and Prometheus

### DIFF
--- a/data-pipeline/README.md
+++ b/data-pipeline/README.md
@@ -1,24 +1,33 @@
 # Data Pipeline Readme
 
 ## Instructions to use object store from an instance:
+
 1. SSH into the instance
+
 ```
 ssh -i ~/.ssh/id_rsa_chameleon cc@A.B.C.D
 ```
+
 2. Install rclone
+
 ```
 curl https://rclone.org/install.sh | sudo bash
 ```
+
 3. Modify FUSE (Filesystem in USErspace) config file
+
 ```
 sudo sed -i '/^#user_allow_other/s/^#//' /etc/fuse.conf
 ```
+
 4. Create a config file and copy the contents into the config file.
-Substitute your UserId(Chameleon->Identity->Users), AppUserId, AppSecret(contact me)
+   Substitute your UserId(Chameleon->Identity->Users), AppUserId, AppSecret(contact me)
+
 ```
 mkdir -p ~/.config/rclone
 nano  ~/.config/rclone/rclone.conf
 ```
+
 ```
 [chi_tacc]
 type = swift
@@ -28,18 +37,53 @@ application_credential_secret = APP_CRED_SECRET
 auth = https://chi.tacc.chameleoncloud.org:5000/v3
 region = CHI@TACC
 ```
+
 5. Run this command and check if your object store is visible
+
 ```
 rclone lsd chi_tacc:
 ```
+
 6. Mount the object store into local file system
+
 ```
 sudo mkdir -p /mnt/object
 sudo chown -R cc /mnt/object
 sudo chgrp -R cc /mnt/object
 rclone mount chi_tacc:object-persist-project47 /mnt/object --read-only --allow-other --daemon
 ```
+
 7. Run this command to check if the data directories are available
+
 ```
 ls /mnt/object
+```
+
+## Instructions to run docker container with MLFlow, Prometheus and Grafana
+
+1. First attach the block storage to your instance(Do this on Chameleon. I'm not sure of any other way) - KVM@TACC->Volumes
+
+2. Run this command to verify
+
+```
+df -h
+```
+
+3. You can run your docker compose command now
+
+```
+HOST_IP=$(curl --silent http://169.254.169.254/latest/meta-data/public-ipv4 ) docker compose -f ~/data-persist-chi/docker/docker-compose-block.yaml up -d
+```
+
+**Things to note:**
+
+1. Make sure the security groups of the instance allow TCP to all the ports(namely 22(SSH), 8888(Jupyter), 8000(MLFlow), 9000(MinIO API), 9001(MinIO Web UI), 9090(Prometheus), 3000(Grafana))
+
+2. Make sure Prometheus and Grafana have permissions to edit their mounted files(TODO: Find a way to automate this)
+
+```
+sudo chmod -R 777 /mnt/block/prometheus_data
+
+sudo mkdir -p /mnt/block/grafana_data
+sudo chown -R 472:472 /mnt/block/grafana_data
 ```

--- a/data-pipeline/docker-compose-block.yaml
+++ b/data-pipeline/docker-compose-block.yaml
@@ -1,0 +1,122 @@
+name: persist_block
+services:
+  minio:
+    image: minio/minio
+    container_name: minio
+    restart: always
+    expose:
+      - "9000"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: "your-access-key"
+      MINIO_ROOT_PASSWORD: "your-secret-key"
+    healthcheck:
+      test: timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
+      interval: 1s
+      timeout: 10s
+      retries: 5
+    command: server /data --console-address ":9001"
+    volumes:
+      - /mnt/block/minio_data:/data
+
+  minio-create-bucket:
+    image: minio/mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set minio http://minio:9000 your-access-key your-secret-key &&
+      if ! mc ls minio/mlflow-artifacts; then
+        mc mb minio/mlflow-artifacts &&
+        echo 'Bucket mlflow-artifacts created'
+      else
+        echo 'Bucket mlflow-artifacts already exists';
+      fi"
+
+  postgres:
+    image: postgres:latest
+    container_name: postgres
+    restart: always
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: mlflowdb
+    ports:
+      - "5432:5432"
+    volumes:
+      - /mnt/block/postgres_data:/var/lib/postgresql/data
+
+  mlflow:
+    image: ghcr.io/mlflow/mlflow:v2.20.2
+    container_name: mlflow
+    restart: always
+    depends_on:
+      - minio
+      - postgres
+      - minio-create-bucket
+    environment:
+      MLFLOW_TRACKING_URI: http://0.0.0.0:8000
+      MLFLOW_S3_ENDPOINT_URL: http://minio:9000
+      AWS_ACCESS_KEY_ID: "your-access-key"
+      AWS_SECRET_ACCESS_KEY: "your-secret-key"
+    ports:
+      - "8000:8000"
+    command: >
+      /bin/sh -c "pip install psycopg2-binary boto3 &&
+      mlflow server --backend-store-uri postgresql://user:password@postgres/mlflowdb 
+      --artifacts-destination s3://mlflow-artifacts/ --serve-artifacts --host 0.0.0.0 --port 8000"
+
+  jupyter:
+    image: quay.io/jupyter/pytorch-notebook:pytorch-2.5.1
+    container_name: jupyter
+    ports:
+      - "8888:8888"
+    shm_size: 8g
+    environment:
+      - MLFLOW_TRACKING_URI=http://${HOST_IP}:8000/
+      - ENTP_DATA_DIR=/mnt/ENTP
+    volumes:
+      - ~/data-persist-chi/workspace:/home/jovyan/work/  # change "~/data-persist-chi/workspace" to the jupyter you want
+      - type: bind
+        source: /mnt/object
+        target: /mnt/ENTP
+        read_only: true
+      - type: bind
+        source: /mnt/object
+        target: /mnt/ENTP
+        read_only: true
+    command: >
+      bash -c "python3 -m pip install mlflow && start-notebook.sh"
+
+  prometheus:
+      image: prom/prometheus
+      container_name: prometheus
+      restart: always
+      ports:
+        - "9090:9090"
+      volumes:
+        - ./prometheus.yaml:/etc/prometheus/prometheus.yaml  # keep prometheus.yaml in this same folder
+        - /mnt/block/prometheus_data:/prometheus
+      command:
+        - --config.file=/etc/prometheus/prometheus.yaml
+        - --storage.tsdb.path=/prometheus
+        - --web.enable-lifecycle
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    restart: always
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: "admin"  # Default admin password
+    volumes:
+      - /mnt/block/grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    command:
+      - "--homepath=/usr/share/grafana"
+      - "--config=/etc/grafana/grafana.ini"

--- a/data-pipeline/prometheus.yml
+++ b/data-pipeline/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s # How often to scrape targets by default
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]
+  - job_name: "mlflow"
+    static_configs:
+      - targets: ["mlflow:8000"]


### PR DESCRIPTION
1. Added block storage of 25GB - block-persist-project47
2. Add docker compose for MLFlow, Prometheus, Grafana
3. Testing their working with Food11 example

TODO:
1. Test the working with our dataset
2. Add dashboards on Grafana dashboard